### PR TITLE
Multiple processes setup

### DIFF
--- a/lib/generators/capistrano/sidekiq/systemd/templates/sidekiq.service.capistrano.erb
+++ b/lib/generators/capistrano/sidekiq/systemd/templates/sidekiq.service.capistrano.erb
@@ -5,7 +5,7 @@ After=syslog.target network.target
 [Service]
 Type=simple
 WorkingDirectory=<%= File.join(fetch(:deploy_to), 'current') %>
-ExecStart=<%= SSHKit.config.command_map[:bundle] %> exec sidekiq -e <%= fetch(:sidekiq_env) %> <%= fetch(:sidekiq_options_per_process).dig(index) if index %>
+ExecStart=<%= fetch(:rvm_absolute_path) || SSHKit.config.command_map[:bundle] %> exec sidekiq -e <%= fetch(:sidekiq_env) %> <%= fetch(:sidekiq_options_per_process).dig(index) if index %>
 ExecReload=/bin/kill -TSTP $MAINPID
 ExecStop=/bin/kill -TERM $MAINPID
 <%="StandardOutput=append:#{fetch(:sidekiq_log)}" if fetch(:sidekiq_log) %>

--- a/lib/generators/capistrano/sidekiq/systemd/templates/sidekiq.service.capistrano.erb
+++ b/lib/generators/capistrano/sidekiq/systemd/templates/sidekiq.service.capistrano.erb
@@ -5,7 +5,7 @@ After=syslog.target network.target
 [Service]
 Type=simple
 WorkingDirectory=<%= File.join(fetch(:deploy_to), 'current') %>
-ExecStart=<%= SSHKit.config.command_map[:bundle] %> exec sidekiq -e <%= fetch(:sidekiq_env) %>
+ExecStart=<%= SSHKit.config.command_map[:bundle] %> exec sidekiq -e <%= fetch(:sidekiq_env) %> <%= fetch(:sidekiq_options_per_process).dig(index) if index %>
 ExecReload=/bin/kill -TSTP $MAINPID
 ExecStop=/bin/kill -TERM $MAINPID
 <%="StandardOutput=append:#{fetch(:sidekiq_log)}" if fetch(:sidekiq_log) %>


### PR DESCRIPTION
Allow starting multiple Sidekiq instances for Sidekiq version > 6.0.
Create files based on `sidekiq_processes` and configure them with `sidekiq_options_per_process`.
Add `rvm_absolute_path` variable, because there are problems with `~/.rvm/bin/rvm`.

